### PR TITLE
MC-6740 add sdk version to intent data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 #### Changes
 #### Additions
 
+- [tinkoff-id] В Intent для запуска авторизации добавлен параметр версии SDK MC-6740
+
 ## 1.0.4
 
 #### Fixed

--- a/tinkoff-id/src/main/java/ru/tinkoff/core/tinkoffId/AppLinkUtil.kt
+++ b/tinkoff-id/src/main/java/ru/tinkoff/core/tinkoffId/AppLinkUtil.kt
@@ -35,6 +35,7 @@ internal object AppLinkUtil {
     private const val QUERY_PARAMETER_CODE = "code"
     private const val QUERY_PARAMETER_AUTH_STATUS_CODE = "auth_status_code"
     private const val QUERY_PARAMETER_REDIRECT_URI = "redirect_uri"
+    private const val QUERY_PARTNER_SDK_VERSION = "partner_sdk_version"
 
     private const val AUTH_STATUS_CODE_SUCCESS = "success"
     private const val AUTH_STATUS_CODE_CANCELLED_BY_USER = "cancelled_by_user"
@@ -51,7 +52,8 @@ internal object AppLinkUtil {
         codeChallengeMethod: String,
         callbackUrl: Uri,
         packageName: String?,
-        redirectUrl: String
+        redirectUrl: String,
+        partnerSdkVersion: String,
     ): Intent {
         val uri = baseUri.buildUpon()
             .appendQueryParameter(QUERY_PARAMETER_CLIENT_ID, clientId)
@@ -60,6 +62,7 @@ internal object AppLinkUtil {
             .appendQueryParameter(QUERY_PARAMETER_CALLBACK_URL, callbackUrl.toString())
             .appendQueryParameter(QUERY_PARAMETER_PACKAGE, packageName)
             .appendQueryParameter(QUERY_PARAMETER_REDIRECT_URI, redirectUrl)
+            .appendQueryParameter(QUERY_PARTNER_SDK_VERSION, partnerSdkVersion)
             .build()
         return Intent(Intent.ACTION_VIEW).apply {
             data = uri

--- a/tinkoff-id/src/main/java/ru/tinkoff/core/tinkoffId/TinkoffIdAuth.kt
+++ b/tinkoff-id/src/main/java/ru/tinkoff/core/tinkoffId/TinkoffIdAuth.kt
@@ -65,7 +65,15 @@ public class TinkoffIdAuth(
         val codeChallenge = CodeVerifierUtil.deriveCodeVerifierChallenge(codeVerifier)
         val codeChallengeMethod = CodeVerifierUtil.getCodeVerifierChallengeMethod()
         codeVerifierStore.codeVerifier = codeVerifier
-        return AppLinkUtil.createAppLink(clientId, codeChallenge, codeChallengeMethod, callbackUrl, applicationContext.packageName, redirectUri)
+        return AppLinkUtil.createAppLink(
+            clientId,
+            codeChallenge,
+            codeChallengeMethod,
+            callbackUrl,
+            applicationContext.packageName,
+            redirectUri,
+            BuildConfig.VERSION_NAME,
+        )
     }
 
     /**

--- a/tinkoff-id/src/test/java/ru/tinkoff/core/tinkoffId/TinkoffIdAuthTest.kt
+++ b/tinkoff-id/src/test/java/ru/tinkoff/core/tinkoffId/TinkoffIdAuthTest.kt
@@ -51,6 +51,7 @@ public class TinkoffIdAuthTest {
         assertThat(queryParam("code_challenge_method")).isNotEmpty()
         assertThat(queryParam("callback_url")).isEqualTo(testUri.toString())
         assertThat(queryParam("package_name")).isNotEmpty()
+        assertThat(queryParam("partner_sdk_version")).isEqualTo(BuildConfig.VERSION_NAME)
     }
 
     @Test


### PR DESCRIPTION
Для логов, которые мы будем посылать в Auth SDK нужна версия SDK TinkoffID. Добавил её в параметры к intent, который открывает наши приложения. Они в свою очередь передают нам в  Auth SDK intent.data в виде объекта Uri, так что доработка потребуется только в самом Auth SDK (распарсить новый параметр)